### PR TITLE
Checking pay status and control pay request classes added. Response handler classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ $response = Epay::request( $controlPay->generateUrl() );
 ```php
 $response = request()->input('response');
 
-if (isset($response))
+if ($response)
 {
-    $payResponse = new BasicAuthResponse( $response );
+    $payResponse = Epay::handleBasicAuth( $response );
 
     $orderId = $payResponse->getOrderId();
 
@@ -102,14 +102,12 @@ $checkPay = Epay::checkPay( [ 'order_id' => '01111111111' ] );
 $response = Epay::request( $checkPay->generateUrl() );
 
 if ($response) {
-    $checkPayResponse = new CheckPayResponse( $response );
+    $checkPayResponse = Epay::handleCheckPay( $response );
     
     Log::info( 'state=' . $checkPayResponse->getPayState() );
     Log::info( 'status=' . ( $checkPayResponse->isSuccess() ? 'success' : 'fail' ));
     Log::info( $checkPayResponse->getResponse() );
 }
-
-return 'response is empty';
 ```
 
 ### Control pay response parser
@@ -132,7 +130,7 @@ if ( is_string($url) ) {
 
     if ($response) {
 
-        $controlPayResponse = new ControlPayResponse( $response );
+        $controlPayResponse = Epay::handleControlPay( $response );
 
         Log::info( 'message=' . $controlPayResponse->getResponseMessage() );
         Log::info( 'status=' . ( $controlPayResponse->isSuccess() ? 'success' : 'fail' ));

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,12 @@
             "Dosarkz\\EpayKazcom\\Tests\\": "tests/",
             "Dosarkz\\EPayKazCom\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Dosarkz\\EPayKazCom\\EpayServiceProvider"
+            ]
+        }
     }
 }

--- a/src/BasicAuth.php
+++ b/src/BasicAuth.php
@@ -1,6 +1,6 @@
 <?php
 namespace Dosarkz\EPayKazCom;
-use Illuminate\Http\Request;
+
 use Illuminate\Support\Facades\Validator;
 
 /**
@@ -14,6 +14,11 @@ class BasicAuth extends Epay
      */
     public $template_path  = 'templates/basic_auth_template.xml';
 
+	/**
+	 * @var string
+	 */
+	private $request_url = '/jsp/process/logon.jsp';
+
     /**
      * @param array $params
      */
@@ -24,8 +29,10 @@ class BasicAuth extends Epay
         $this->order_id         = isset($params['order_id'])    ? $params['order_id'] : null;
         $this->currency         = isset($params['currency'])    ? $params['currency'] : $this->currency;
         $this->amount           = isset($params['amount'])      ? $params['amount'] : 0;
-        $this->email            = isset($params['email'])       ? $params['email'] : "";
+        $this->email            = isset($params['email'])       ? $params['email'] : '';
         $this->hashed           = isset($params['hashed'])      ? $params['hashed'] : false;
+	    $this->back_link        = isset($params['back_link'])   ? $params['back_link'] : false;
+
         $this->template         = $this->generateXml();
         $this->appendix         = $this->generateAppendix();
     }
@@ -64,28 +71,28 @@ class BasicAuth extends Epay
     }
 
     /**
-     * @return string
+     * @return string|array
      */
     public function generateUrl()
     {
-        $request = new Request();
-        $back_link          = config('epay.EPAY_BACK_LINK');
-        $post_link          = config('epay.EPAY_POST_LINK');
-        $form_template      = config('epay.EPAY_FORM_TEMPLATE');
-        $test_mode          = config('epay.pay_test_mode');
-        $failure_post_link  = config('epay.EPAY_FAILURE_POST_LINK');
+	    $back_link          = $this->back_link ? $this->back_link : config('epay.EPAY_BACK_LINK');
+	    $post_link          = config('epay.EPAY_POST_LINK');
+	    $form_template      = config('epay.EPAY_FORM_TEMPLATE');
+	    $failure_post_link  = config('epay.EPAY_FAILURE_POST_LINK');
 
-        $request->merge([
-            'Signed_Order_B64'  =>  $this->template,
-            'BackLink'          =>  isset($back_link) ? $back_link : null,
-            'PostLink'          =>  isset($post_link) ? $post_link : null,
-            'email'             =>  $this->email,
-            'FailurePostLink'   =>  isset($failure_post_link) ? $failure_post_link : null,
-            'appendix'          =>  $this->appendix,
-            'template'          =>  isset($form_template) ? $form_template : null
-        ]);
+    	$params = collect(
+	        [
+		        'Signed_Order_B64'  =>  $this->template,
+		        'BackLink'          =>  isset($back_link) ? $back_link : null,
+		        'PostLink'          =>  isset($post_link) ? $post_link : null,
+		        'email'             =>  $this->email,
+		        'FailurePostLink'   =>  isset($failure_post_link) ? $failure_post_link : null,
+		        'appendix'          =>  $this->appendix,
+		        'template'          =>  isset($form_template) ? $form_template : null
+	        ]
+        );
 
-        $validator = Validator::make($request->all(),
+        $validator = Validator::make( $params->all(),
             [
                 'Signed_Order_B64'      => 'required',
                 'email'                 => 'email',
@@ -102,7 +109,7 @@ class BasicAuth extends Epay
             return $validator->errors();
         }
 
-        $params = http_build_query($request->only([
+        $queryString = http_build_query( $params->only([
             'Signed_Order_B64',
             'email',
             'BackLink',
@@ -110,15 +117,10 @@ class BasicAuth extends Epay
             'FailurePostLink',
             'appendix',
             'template',
-        ]));
+        ])->toArray());
 
-        if($test_mode == true)
-        {
-            $url = 'https://testpay.kkb.kz/jsp/process/logon.jsp';
-        }else{
-            $url = 'https://epay.kkb.kz/jsp/process/logon.jsp';
-        }
+        $url = $this->epay_server_url . $this->request_url;
 
-        return $url.'?'.$params;
+        return $url.'?'.$queryString;
     }
 }

--- a/src/BasicAuthResponse.php
+++ b/src/BasicAuthResponse.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Dosarkz\EPayKazCom;
+
+/**
+ * Parser for BasicPay response
+ *
+ * Class BasicAuthResponse
+ * @package Dosarkz\EPayKazCom
+ */
+class BasicAuthResponse extends Response {
+
+	use ResponseBankSignValidatable;
+
+	protected $mappedParams = [
+		'amount'        => 'bank.results.payment.@attributes.amount',
+		'merchant_id'   => 'bank.results.payment.@attributes.merchant_id',
+		'response_code' => 'bank.results.payment.@attributes.response_code',
+		'reference'     => 'bank.results.payment.@attributes.reference',
+		'approval_code' => 'bank.results.payment.@attributes.approval_code',
+		'currency'      => 'bank.customer.merchant.order.@attributes.currency',
+		'order_id'      => 'bank.customer.merchant.order.@attributes.order_id'
+	];
+
+	protected $validatingParams = [ 'amount', 'merchant_id', 'response_code' ];
+
+	/**
+	 * BasicAuthResponse constructor.
+
+	 * @param string $rawResponse
+	 * @param array|null $mappedParams
+	 */
+	public function __construct( $rawResponse, $mappedParams = [] ) {
+
+		parent::__construct( new ResponseParser($rawResponse), $mappedParams );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getReference(){
+
+		return $this->reference;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getApprovalCode(){
+
+		return $this->approval_code;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getAmount(){
+
+		return $this->amount;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCurrencyCode(){
+
+		return $this->currency;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getOrderId(){
+
+		return $this->order_id;
+	}
+
+	public function isSuccess( array $params = [] ) {
+
+		$defaultParams = [
+			'merchant_id' => app()->get('epay')->merchant_id,
+			'response_code' => '00'
+		];
+
+		$params = array_merge( $params, $defaultParams );
+
+		return $this->validateSign() && parent::isSuccess( $params );
+	}
+}

--- a/src/CheckPay.php
+++ b/src/CheckPay.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Dosarkz\EPayKazCom;
+
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Class CheckPay
+ * @package Dosarkz\EPayKazCom
+ */
+class CheckPay extends Epay {
+
+	/**
+	 * @var string
+	 */
+	public $template_path  = 'templates/check_order_template.xml';
+
+	/**
+	 * @var string
+	 */
+	private $request_url = '/jsp/remote/checkOrdern.jsp';
+
+	/**
+	 * CheckPay constructor.
+	 *
+	 * @param array $params
+	 */
+	public function __construct(array $params = [])
+	{
+		parent::__construct();
+
+		$this->order_id = isset($params['order_id']) ? $params['order_id'] : null;
+
+		$this->template = $this->generateXml();
+	}
+
+	/**
+	 * @return null|string
+	 */
+	private function generateXml()
+	{
+		if(file_exists(__DIR__.'/'.$this->template_path)){
+
+			$xml = $this->readXmlFile(__DIR__.'/'.$this->template_path);
+
+			$array = [
+				'ORDER_ID',
+				'MERCHANT_ID'
+			];
+
+			$params = $this->getListParams($array);
+			$header_template = $this->setParamsToTemplate($xml,$params);
+			$template =  $this->generateXmlTemplate($header_template,$this->kkb);
+
+			return $template;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Generate url for Epay request
+	 *
+	 * @return string|array
+	 */
+	public function generateUrl(){
+
+		$params = collect( [
+			'order_id' => $this->order_id
+		]);
+
+		$validator = Validator::make( $params->all(),
+			[
+				'order_id'      => 'required'
+			]
+		);
+
+		if ($validator->fails())
+		{
+			return $validator->errors();
+		}
+
+		$url = $this->epay_server_url . $this->request_url;
+
+		return $url . '?' . urlencode( $this->template );
+
+	}
+}

--- a/src/CheckPayResponse.php
+++ b/src/CheckPayResponse.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Dosarkz\EPayKazCom;
+
+/**
+ * Parser for CheckPay response
+ *
+ * Class CheckPayResponse
+ * @package Dosarkz\EPayKazCom
+ */
+class CheckPayResponse extends Response {
+
+	use ResponseBankSignValidatable;
+
+	protected $mappedParams = [
+		'order_id'          => 'bank.merchant.order.@attributes.id',
+		'merchant_id'       => 'bank.merchant.@attributes.id',
+		'amount'            => 'bank.response.@attributes.amount',
+		'status'            => 'bank.response.@attributes.status',
+		'result'            => 'bank.response.@attributes.result',
+		'payment'           => 'bank.response.@attributes.payment',
+		'currencycode'      => 'bank.response.@attributes.currencycode',
+		'timestamp'         => 'bank.response.@attributes.timestamp',
+		'reference'         => 'bank.response.@attributes.reference',
+		'cardhash'          => 'bank.response.@attributes.cardhash',
+		'card_to'           => 'bank.response.@attributes.card_to',
+		'approval_code'     => 'bank.response.@attributes.approval_code',
+		'msg'               => 'bank.response.@attributes.msg',
+		'secure'            => 'bank.response.@attributes.secure',
+		'card_bin'          => 'bank.response.@attributes.card_bin',
+		'payername'         => 'bank.response.@attributes.payername',
+		'payermail'         => 'bank.response.@attributes.payermail',
+		'payerphone'        => 'bank.response.@attributes.payerphone',
+		'c_hash'            => 'bank.response.@attributes.c_hash',
+		'recur'             => 'bank.response.@attributes.recur',
+		'recur_freq'        => 'bank.response.@attributes.recur_freq',
+		'recur_exp'         => 'bank.response.@attributes.recur_exp',
+		'person_id'         => 'bank.response.@attributes.person_id',
+
+		'OrderID'           => 'bank.response.@attributes.OrderID',
+		'SessionID'         => 'bank.response.@attributes.SessionID',
+		'intreference'      => 'bank.response.@attributes.intreference',
+		'AcceptRejectCode'  => 'bank.response.@attributes.AcceptRejectCode',
+
+	];
+
+	protected $validatingParams = [ 'merchant_id' ];
+
+	/**
+	 * BasicAuthResponse constructor.
+
+	 * @param string $rawResponse
+	 * @param array|null $mappedParams
+	 */
+	public function __construct( $rawResponse, $mappedParams = [] ) {
+
+		parent::__construct( new ResponseParser($rawResponse), $mappedParams );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getReference(){
+
+		return $this->reference;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getApprovalCode(){
+
+		return $this->approval_code;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getAmount(){
+
+		return $this->amount;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCurrencyCode(){
+
+		return $this->currencycode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getPayState(){
+
+		if ($this->payment == 'false' && $this->status == 2 ) return 'CANCELED';
+		if ($this->payment == 'true' && $this->status == 2 && $this->result == 0) return 'APPROVED';
+		if ($this->payment == 'true' && $this->status == 0 && $this->result == 0) return 'AUTH';
+		if ($this->payment == 'false' && $this->status == 7 && $this->result == 7) return 'NOT_FOUND';
+		if ($this->payment == 'false' && $this->status == 8 && $this->result == 8) return 'NOT_PAYED';
+		if ($this->payment == 'false' && $this->status == 9 && $this->result == 9) return 'SYSTEM_ERROR';
+
+		return 'UNKNOWN';
+	}
+
+	public function isSuccess( array $params = [] ) {
+
+		$defaultParams = [
+			'merchant_id' => app()->get('epay')->merchant_id,
+		];
+
+		$params = array_merge( $params, $defaultParams );
+
+		return $this->validateSign()
+		       && parent::isSuccess( $params )
+		       && in_array( $this->getPayState(), [ 'APPROVED', 'AUTH'] );
+	}
+
+}

--- a/src/ControlPay.php
+++ b/src/ControlPay.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Dosarkz\EPayKazCom;
+
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Class ControlPay
+ * @package Dosarkz\EPayKazCom
+ */
+class ControlPay extends Epay {
+
+	/**
+	 * @var string
+	 */
+	public $template_path  = 'templates/remote_template.xml';
+
+	/**
+	 * @var string
+	 */
+	private $request_url = '/jsp/remote/control.jsp';
+
+	/**
+	 * ControlPay constructor.
+	 *
+	 * @param array $params
+	 */
+	public function __construct(array $params = [])
+	{
+		parent::__construct();
+
+		$this->order_id = isset($params['order_id']) ? $params['order_id'] : null;
+		$this->command_type = isset($params['command_type']) ? $params['command_type'] : null;
+		$this->reference = isset($params['reference']) ? $params['reference'] : null;
+		$this->approval_code = isset($params['approval_code']) ? $params['approval_code'] : null;
+		$this->amount = isset($params['amount']) ? $params['amount'] : null;
+		$this->currency = isset($params['currency']) ? $params['currency'] : null;
+		$this->reason = isset($params['reason']) ? $params['reason'] : null;
+
+		$this->template = $this->generateXml();
+	}
+
+	/**
+	 * @return null|string
+	 */
+	private function generateXml()
+	{
+		if(file_exists(__DIR__.'/'.$this->template_path)){
+
+			$xml = $this->readXmlFile(__DIR__.'/'.$this->template_path);
+
+			$array = [
+				'MERCHANT_ID',
+				'ORDER_ID',
+				'COMMAND_TYPE',
+				'REFERENCE',
+				'APPROVAL_CODE',
+				'AMOUNT',
+				'CURRENCY',
+				'REASON'
+			];
+
+			$params = $this->getListParams($array);
+			$header_template = $this->setParamsToTemplate($xml,$params);
+			$template =  $this->generateXmlTemplate($header_template,$this->kkb);
+
+			return $template;
+		}
+
+		return null;
+	}
+
+
+	/**
+	 * Generate url for Epay request
+	 *
+	 * @return string|array
+	 */
+	public function generateUrl(){
+
+		$params = collect( [
+			'order_id'      => $this->order_id,
+			'command_type'  => $this->command_type,
+			'reference'     => $this->reference,
+			'approval_code' => $this->approval_code,
+			'amount'        => $this->amount,
+			'currency'      => $this->currency,
+			'reason'        => $this->reason
+		]);
+
+		$validator = Validator::make( $params->all(),
+			[
+				'order_id'          => 'required',
+				'command_type'      => 'required|in:reverse,complete,refund',
+				'reference'         => 'required',
+				'approval_code'     => 'required',
+				'amount'            => 'required',
+				'currency'          => 'required',
+				'reason'            => 'string',
+			]
+		);
+
+		if ($validator->fails())
+		{
+			return $validator->errors();
+		}
+
+		$url = $this->epay_server_url . $this->request_url;
+
+		return $url . '?' . urlencode( $this->template );
+
+	}
+}

--- a/src/ControlPayResponse.php
+++ b/src/ControlPayResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Dosarkz\EPayKazCom;
+
+
+/**
+ * Parser for ControlPay response
+ *
+ * Class ControlPayResponse
+ * @package Dosarkz\EPayKazCom
+ */
+class ControlPayResponse extends Response {
+
+	use ResponseBankSignValidatable;
+
+	protected $mappedParams = [
+		'merchant_id' => 'bank.merchant.@attributes.id',
+		'response_code' => 'bank.response.@attributes.code',
+		'response_message' => 'bank.response.@attributes.message',
+		'remaining_amount' => 'bank.response.@attributes.remaining_amount',
+	];
+
+	protected $validatingParams = [ 'merchant_id', 'response_code' ];
+
+	/**
+	 * ControlPayResponse constructor.
+	 * @param string $rawResponse
+	 * @param array|null $mappedParams
+	 */
+	public function __construct( $rawResponse, $mappedParams = [] ) {
+
+		parent::__construct( new ResponseParser($rawResponse), $mappedParams );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getResponseCode(){
+
+		return $this->response_code;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getResponseMessage(){
+
+		return $this->response_message;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRemainingAmount(){
+
+		return $this->remaining_amount;
+	}
+
+	public function isSuccess( array $params = [] ) {
+
+		$defaultParams = [
+			'merchant_id' => app()->get('epay')->merchant_id,
+			'response_code' => '00'
+		];
+
+		$params = array_merge( $params, $defaultParams );
+
+		return $this->validateSign() && parent::isSuccess( $params );
+	}
+}

--- a/src/Epay.php
+++ b/src/Epay.php
@@ -153,12 +153,38 @@ class Epay
     }
 
 	/**
+	 * Parse basic auth response
+	 *
+	 * @param string $rawResponse
+	 * @param array|null $mappedParams
+	 *
+	 * @return BasicAuthResponse
+	 */
+	public function handleBasicAuth($rawResponse, $mappedParams = [])
+	{
+		return new BasicAuthResponse($rawResponse, $mappedParams);
+	}
+
+	/**
 	 * @param $params
 	 * @return CheckPay
 	 */
 	public function checkPay($params)
 	{
 		return new CheckPay($params);
+	}
+
+	/**
+	 * Parse check pay response
+	 *
+	 * @param string $rawResponse
+	 * @param array|null $mappedParams
+	 *
+	 * @return CheckPayResponse
+	 */
+	public function handleCheckPay($rawResponse, $mappedParams = [])
+	{
+		return new CheckPayResponse($rawResponse, $mappedParams);
 	}
 
 	/**
@@ -170,7 +196,20 @@ class Epay
 		return new ControlPay($params);
 	}
 
-    public function recurrentAuth($params)
+	/**
+	 * Parse control pay response
+	 *
+	 * @param string $rawResponse
+	 * @param array|null $mappedParams
+	 *
+	 * @return ControlPayResponse
+	 */
+	public function handleControlPay($rawResponse, $mappedParams = [])
+	{
+		return new ControlPayResponse($rawResponse, $mappedParams);
+	}
+
+	public function recurrentAuth($params)
     {
         return new RecurAuthPay($params);
     }

--- a/src/Epay.php
+++ b/src/Epay.php
@@ -1,9 +1,6 @@
 <?php
 namespace Dosarkz\EPayKazCom;
 
-
-use Illuminate\Container\Container;
-
 class Epay
 {
     /**
@@ -82,6 +79,10 @@ class Epay
      * @var
      */
     public $approval_code;
+	/**
+	 * @var
+	 */
+	public $reason;
     /**
      * @var
      */
@@ -102,11 +103,21 @@ class Epay
      * @var
      */
     public $template;
+
     /**
      * @var
      */
     public $appendix;
 
+	/**
+	 * @var string
+	 */
+	public $epay_server_url;
+
+	/**
+	 * @var int
+	 */
+	public $request_timeout = 10;
 
     public function __construct()
     {
@@ -141,6 +152,23 @@ class Epay
         return new BasicAuth($params);
     }
 
+	/**
+	 * @param $params
+	 * @return CheckPay
+	 */
+	public function checkPay($params)
+	{
+		return new CheckPay($params);
+	}
+
+	/**
+	 * @param $params
+	 * @return ControlPay
+	 */
+	public function controlPay($params)
+	{
+		return new ControlPay($params);
+	}
 
     public function recurrentAuth($params)
     {
@@ -154,7 +182,9 @@ class Epay
         $this->merchant_id              = '92061101';
         $this->private_key_path         = __DIR__.'/certificates/test_prv.pem';
         $this->private_key_pass         = 'nissan';
-        $this->public_key_path          = null;
+        $this->public_key_path          = __DIR__.'/certificates/kkbca.pem';
+        $this->epay_server_url          = 'https://testpay.kkb.kz';
+
     }
 
     private function setProductionParams()
@@ -165,6 +195,8 @@ class Epay
         $this->private_key_path         = config('epay.PRIVATE_KEY_PATH');
         $this->private_key_pass         = config('epay.PRIVATE_KEY_PASS');
         $this->public_key_path          = config('epay.PUBLIC_KEY_PATH');
+	    $this->epay_server_url          = 'https://epay.kkb.kz';
+
     }
 
 
@@ -217,6 +249,7 @@ class Epay
                 $template =  $this->generateXmlTemplate($header_template,$kkb);
 
                 break;
+
         }
 
         return $template;
@@ -288,23 +321,21 @@ class Epay
         curl_setopt($ch, CURLOPT_FAILONERROR, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);// allow redirects
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); // return into a variable
-        curl_setopt($ch, CURLOPT_TIMEOUT, 3); // times out after 4s
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->request_timeout); // times out after 4s
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
         $result = curl_exec($ch); // run the whole process
         curl_close($ch);
         return $result;
     }
 
-    /**
-     * @param $path
-     * @return string
-     */
-    public  function readXmlFile($path)
-    {
-        $doc = new \DOMDocument();
-        $doc->load($path);
-        return $doc->saveXML($doc->documentElement);
-    }
-
-
+	/**
+	 * @param $path
+	 * @return string
+	 */
+	public  function readXmlFile($path)
+	{
+		$doc = new \DOMDocument();
+		$doc->load($path);
+		return $doc->saveXML($doc->documentElement);
+	}
 }

--- a/src/EpayServiceProvider.php
+++ b/src/EpayServiceProvider.php
@@ -1,8 +1,9 @@
 <?php
 namespace Dosarkz\EPayKazCom;
 
-use Illuminate\Support\Facades\App;
+use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
+use Dosarkz\EPayKazCom\Facades\Epay as EpayFacade;
 
 class EpayServiceProvider extends ServiceProvider
 {
@@ -29,6 +30,9 @@ class EpayServiceProvider extends ServiceProvider
      */
     public function register()
     {
+	    $loader = AliasLoader::getInstance();
+	    $loader->alias('Crud', EpayFacade::class);
+
         $this->app->singleton("epay", function($app)
         {
             return new Epay();

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Dosarkz\EPayKazCom;
+
+
+/**
+ * Base Epay response with params validating
+ *
+ * Class Response
+ * @package Dosarkz\EPayKazCom
+ */
+abstract class Response {
+
+	/**
+	 * Array of parameters to be checked
+	 *
+	 * @var array
+	 */
+	protected $validatingParams = [ ];
+
+	/**
+	 * Array of parameters to be mapped
+	 *
+	 * @var array
+	 */
+	protected $mappedParams = [ ];
+
+	/**
+	 * Response parser
+	 *
+	 * @var ResponseParser
+	 */
+	protected $parsedResponse = null;
+
+	/**
+	 * Response constructor.
+	 * @param ResponseParser $parsedResponse
+	 * @param array $mappedParams
+	 */
+	public function __construct( $parsedResponse,  $mappedParams = []) {
+
+		$this->mappedParams = array_merge( $this->mappedParams, $mappedParams );
+
+		$this->parsedResponse = $parsedResponse;
+	}
+
+
+	/**
+	 * Validate mapped params to provided params
+	 *
+	 * @param $params
+	 * @return bool
+	 */
+	protected function validateParams( $params ){
+
+		foreach ($this->validatingParams as $param){
+
+			if ( $this->parsedResponse->getResponse( $this->mappedParams[$param] ) != $params[$param])
+				return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Determines the overall result of the response
+	 *
+	 * @param array $params
+	 * @return bool
+	 */
+	public function isSuccess( array $params = [] ){
+
+		return $this->validateParams( $params );
+	}
+
+	/**
+	 * Magic access to mapped params
+	 *
+	 * @param $name
+	 * @return mixed|null
+	 */
+	public function __get( $name ) {
+
+		return isset($this->mappedParams[$name])
+			? $this->parsedResponse->getResponse( $this->mappedParams[$name] )
+			: null ;
+	}
+
+
+	/**
+	 * Get whole parsed response data
+	 *
+	 * @return mixed|null
+	 */
+	 public function getResponse(){
+
+		return $this->parsedResponse ? $this->parsedResponse->getResponse() : null;
+	}
+
+}

--- a/src/ResponseBankSignValidatable.php
+++ b/src/ResponseBankSignValidatable.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dr_sharp
+ * Date: 11.07.2018
+ * Time: 14:24
+ */
+
+namespace Dosarkz\EPayKazCom;
+
+
+trait ResponseBankSignValidatable {
+
+	private function validateSign() {
+
+		$bankField = $this->parsedResponse->getRawBankField();
+
+		$bankFieldSign = $this->parsedResponse->getResponse('bank_sign');
+
+		if ($bankField && $bankFieldSign) {
+
+			$kkb = new KkbSign();
+
+			$kkb->invert();
+
+			return ( $kkb->check_sign64($bankField, $bankFieldSign, app()->get('epay')->public_key_path ) == 1 );
+		} else {
+
+			return false;
+		}
+	}
+}

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Dosarkz\EPayKazCom;
+
+use Illuminate\Support\Arr;
+
+/**
+ * Base Epay response parser
+ *
+ * Class ResponseParser
+ * @package Dosarkz\EPayKazCom
+ */
+class ResponseParser {
+
+	/**
+	 * @var string
+	 */
+	protected $rawResponse;
+
+	/**
+	 * @var array
+	 */
+	protected $parsedData;
+
+	/**
+	 * EpayResponseParser constructor.
+	 *
+	 * @param string $rawResponse
+	 */
+	public function __construct( $rawResponse ) {
+
+		$this->rawResponse = $rawResponse;
+
+		$xmlElement = simplexml_load_string($rawResponse);
+
+		$this->parsedData = json_decode( json_encode( (array) $xmlElement ), true);
+	}
+
+	/**
+	 * Get raw bank field
+	 *
+	 * @return string
+	 */
+	public function getRawBankField() {
+
+		$matches = [];
+
+		preg_match('/(\<bank[\s\>].*\<\/bank>)/', $this->rawResponse, $matches);
+
+		return count($matches) ? $matches[0] : '';
+	}
+
+	/**
+	 * Get response field value, using dot notation
+	 *
+	 * @param string|null $key
+	 * @return mixed
+	 */
+	public function getResponse( $key = null ) {
+
+		return $key ? Arr::get($this->parsedData, $key) : $this->parsedData;
+	}
+
+}

--- a/src/templates/check_order_template.xml
+++ b/src/templates/check_order_template.xml
@@ -1,0 +1,1 @@
+<merchant id="[MERCHANT_ID]"><order id="[ORDER_ID]"/></merchant>

--- a/src/templates/remote_template.xml
+++ b/src/templates/remote_template.xml
@@ -1,1 +1,1 @@
-<merchant id="[MERCHANT_ID]"><command type="[COMMAND_TYPE]"/><payment reference="[REFERENCE]" approval_code="[APPROVAL_CODE]" orderid="[ORDER_ID]" amount="[AMOUNT]" currency_code="[CURRENCY]"/><reason>Only for reverse</reason></merchant>
+<merchant id="[MERCHANT_ID]"><command type="[COMMAND_TYPE]"/><payment reference="[REFERENCE]" approval_code="[APPROVAL_CODE]" orderid="[ORDER_ID]" amount="[AMOUNT]" currency_code="[CURRENCY]"/><reason>[REASON]</reason></merchant>


### PR DESCRIPTION
Hello everyone, now package can send requests for checking payment state, for control payment (complete, revers, refund). Also package can handle and parse responses for each type of request.

In addition, there are some small nice things:
service-provider and facade self-register for laravel 5.5+
back_link override for BasicAuth,
mapped fields and magic access for them in response handler